### PR TITLE
task(AP-9045): Добавить текст для отображения при отсутствии дефолтной или сбросе выбранной даты

### DIFF
--- a/packages/ui-react/src/components/date-picker/index.tsx
+++ b/packages/ui-react/src/components/date-picker/index.tsx
@@ -129,7 +129,11 @@ export interface IProps {
     /**
      * Параметр `isDateInputsReadOnly` позволяет отключить ввод данных в инпуты даты
      */
-    readonly isDateInputsReadOnly?: boolean
+    readonly isDateInputsReadOnly?: boolean,
+    /**
+     * Параметр `noValueText` текст, которые отображается при отсутствии дефолтной или сбросе выбранной даты
+     */
+    readonly noValueText?: string
 }
 
 interface ICalendarDate {
@@ -200,6 +204,7 @@ export const DatePicker = ({
     defaultSelectedDate = defaultSelectedDateEmpty,
     i18nConfig = defaultTranslationConfig,
     dateFormat = defaultFormatDate,
+    noValueText = '',
     ...props
 }: IProps) => {
     const cn = useClassnames(style, props.className);
@@ -841,7 +846,7 @@ export const DatePicker = ({
                 onClick={onClickTrigger}
             >
                 <Text presetSize="body">
-                    {displayDate ?? ''}
+                    {displayDate ?? noValueText}
                 </Text>
                 <IconCalendarDates
                     svg={{
@@ -850,7 +855,7 @@ export const DatePicker = ({
                 />
             </button>
         );
-    }, [props.readOnly, displayDate, props.isDateRange, props.isMobile, props.disabled]);
+    }, [props.readOnly, displayDate, props.isDateRange, props.isMobile, props.disabled, noValueText]);
 
     const onCloseCalendar = () => {
         setCalendar(defaultCalendar);


### PR DESCRIPTION
При отсутствии или сбросе выбранной даты необходимо иметь возможность отображать текст (значение по умолчанию/лейбл)
<img width="187" alt="Снимок экрана 2025-02-12 в 12 43 15" src="https://github.com/user-attachments/assets/229dff6f-72d1-4fcb-b8d3-90ccff0b9813" />
